### PR TITLE
Include ability for protocols to borrow

### DIFF
--- a/contracts/CErc20.sol
+++ b/contracts/CErc20.sol
@@ -86,17 +86,6 @@ contract CErc20 is CToken, CErc20Interface {
     }
 
     /**
-     * @notice Sender repays a borrow belonging to borrower
-     * @param borrower the account with the debt being payed off
-     * @param repayAmount The amount to repay
-     * @return uint 0=success, otherwise a failure (see ErrorReporter.sol for details)
-     */
-    function repayBorrowBehalf(address borrower, uint repayAmount) external returns (uint) {
-        (uint err,) = repayBorrowBehalfInternal(borrower, repayAmount);
-        return err;
-    }
-
-    /**
      * @notice The sender liquidates the borrowers collateral.
      *  The collateral seized is transferred to the liquidator.
      * @param borrower The borrower of this cToken to be liquidated

--- a/contracts/ComptrollerG5.sol
+++ b/contracts/ComptrollerG5.sol
@@ -13,7 +13,7 @@ import "./Governance/Comp.sol";
  * @title Compound's Comptroller Contract
  * @author Compound (modified by Arr00)
  */
-contract ComptrollerG5 is ComptrollerV4Storage, ComptrollerInterface, ComptrollerErrorReporter, Exponential {
+contract ComptrollerG5 is ComptrollerV5Storage, ComptrollerInterface, ComptrollerErrorReporter, Exponential {
     /// @notice Emitted when an admin supports a market
     event MarketListed(CToken cToken);
 
@@ -94,8 +94,6 @@ contract ComptrollerG5 is ComptrollerV4Storage, ComptrollerInterface, Comptrolle
 
     // liquidationIncentiveMantissa must be no greater than this value
     uint internal constant liquidationIncentiveMaxMantissa = 1.5e18; // 1.5
-
-    mapping(address => bool) public protocols;
 
     constructor() public {
         admin = msg.sender;

--- a/contracts/ComptrollerStorage.sol
+++ b/contracts/ComptrollerStorage.sol
@@ -140,6 +140,9 @@ contract ComptrollerV5Storage is ComptrollerV4Storage {
     // @notice The supplyCapGuardian can set supplyCaps to any number for any market. Lowering the supply cap could disable supplying to the given market.
     address public supplyCapGuardian;
 
+    // @notice protocols allowed to borrow and repay without collateral
+    mapping(address => bool) public protocols;
+
     // @notice Supply caps enforced by mintAllowed for each cToken address. Defaults to zero which corresponds to unlimited supplying.
     mapping(address => uint) public supplyCaps;
 }


### PR DESCRIPTION
3 core modifications;

Add protocol whitelist. This will allow third party protocols to borrow without providing collateral. This enhancement will change cream into a lending reserve. Protocols such as Compound, Aave, Alpha, Yearn can borrow assets and lend them out to their users while collecting interest rates. This allows for greater capital efficiency across protocols.

Updated Storage to V5

Removed ability to repayOnBehalf, to make accounting for downstream protocols easier.

This is the recommended version for the new WETH, DAI, y3p meta market.