### PR TITLE
Remove `_addCompMarkets` and `_dropCompMarkets`

### DIFF
--- a/scenario/src/Contract/Comptroller.ts
+++ b/scenario/src/Contract/Comptroller.ts
@@ -14,6 +14,7 @@ interface ComptrollerMethods {
   liquidationIncentiveMantissa(): Callable<number>
   closeFactorMantissa(): Callable<number>
   getBlockNumber(): Callable<number>
+  setBlockNumber(encodedNumber): Sendable<number>
   collateralFactor(string): Callable<string>
   markets(string): Callable<{0: boolean, 1: number, 2?: boolean}>
   _setMintPaused(bool): Sendable<number>
@@ -49,6 +50,7 @@ interface ComptrollerMethods {
   _dropCompMarket(market: string): Sendable<void>
   getCompMarkets(): Callable<string[]>
   refreshCompSpeeds(): Sendable<void>
+  _setCompSpeeds(cTokens:string[], speeds:encodedNumber[]): Sendable<void>
   compRate(): Callable<number>
   compSupplyState(string): Callable<string>
   compBorrowState(string): Callable<string>

--- a/spec/scenario/Flywheel/Flywheel.scen
+++ b/spec/scenario/Flywheel/Flywheel.scen
@@ -3,11 +3,11 @@ Macro FlywheelComptroller price=1.0 borrowRate=0.000005 compInitAmount=5000000e1
     Unitroller Deploy
     PriceOracle Deploy Fixed price
     PriceOracleProxy Deploy Admin (PriceOracle Address) (Address Zero) (Address Zero) (Address Zero) (Address Zero) (Address Zero) (Address Zero)
-    ----g2
+    -- g2
     ComptrollerImpl Deploy ScenarioG2 ComptrollerScenG2
     Unitroller SetPendingImpl ComptrollerScenG2
     ComptrollerImpl ComptrollerScenG2 BecomeG2
-    --list some tokens
+    -- list some tokens
     Comptroller SetPriceOracle (PriceOracleProxy Address)
     Comptroller SetMaxAssets 20
     Comptroller SetCloseFactor 0.5
@@ -16,10 +16,10 @@ Macro FlywheelComptroller price=1.0 borrowRate=0.000005 compInitAmount=5000000e1
     NewCToken BAT cBAT
     Support cZRX collateralFactor:0.5
     Support cBAT collateralFactor:0.5
-    -- final
-    ComptrollerImpl Deploy ScenarioG3 ComptrollerScen
-    Unitroller SetPendingImpl ComptrollerScen
-    ComptrollerImpl ComptrollerScen BecomeG3 1e18 [cZRX cBAT]
+    -- g3
+    ComptrollerImpl Deploy ScenarioG3 ComptrollerScenG3
+    Unitroller SetPendingImpl ComptrollerScenG3
+    ComptrollerImpl ComptrollerScenG3 BecomeG3 1e18 [cZRX cBAT]
     Erc20 Deploy Standard COMP "COMP Token" 18
     Give (Address Comptroller) compInitAmount COMP
     Comptroller Send "setCompAddress(address)" (Address COMP)
@@ -32,6 +32,13 @@ Macro InitSpeeds
     EnterMarkets Coburn cBAT
     Borrow Coburn 1e18 cZRX
     Comptroller RefreshCompSpeeds
+
+Macro UpgradeComptroller
+    -- g6
+    ComptrollerImpl Deploy Scenario ComptrollerScenG6
+    Unitroller SetPendingImpl ComptrollerScenG6
+    ComptrollerImpl ComptrollerScenG6 Become
+    Comptroller Send "setCompAddress(address)" (Address COMP)
 
 Test "Accrue COMP during a mint"
     FlywheelComptroller
@@ -207,15 +214,33 @@ Test "TransferComp handles running out of COMP in Comptroller correctly"
     Assert Equal (Comptroller CompAccrued Geoff) 0
     Assert Equal (Erc20 COMP TokenBalance Geoff) 2e18
 
-Test "Changing COMP rate continues to distribute at the correct speed"
+Test "Changing COMP speed continues to distribute at the correct speed"
     FlywheelComptroller
     InitSpeeds
     --
     Assert Equal (Comptroller CompSpeed cZRX) 1e18
     FastForward 10 Blocks
-    Comptroller SetCompRate 2e18
+    Assert Equal (Comptroller BlockNumber) 10
+    -- upgrade comptroller to g6 for SetCompSpeeds
+    UpgradeComptroller
+    Comptroller SetBlockNumber 10
+    Assert Equal (Comptroller BlockNumber) 10
+    Comptroller SetCompSpeeds (cZRX) (2e18)
     Assert Equal (Comptroller CompSpeed cZRX) 2e18
+    -- 10 + 20 = 30
     FastForward 10 Blocks
     Comptroller ClaimComp Geoff
     Assert Equal (Comptroller CompAccrued Geoff) 0
     Assert Equal (Erc20 COMP TokenBalance Geoff) 30e18
+    -- 30 + 20 = 50
+    FastForward 10 Blocks
+    Comptroller SetCompSpeeds (cZRX) (0)
+    Assert Equal (Comptroller CompSpeed cZRX) 0
+    Comptroller ClaimComp Geoff
+    Assert Equal (Comptroller CompAccrued Geoff) 0
+    Assert Equal (Erc20 COMP TokenBalance Geoff) 50e18
+    -- 50 + 0 = 50
+    FastForward 10 Blocks
+    Comptroller ClaimComp Geoff
+    Assert Equal (Comptroller CompAccrued Geoff) 0
+    Assert Equal (Erc20 COMP TokenBalance Geoff) 50e18

--- a/tests/Contracts/ComptrollerScenario.sol
+++ b/tests/Contracts/ComptrollerScenario.sol
@@ -4,8 +4,17 @@ import "../../contracts/Comptroller.sol";
 
 contract ComptrollerScenario is Comptroller {
     uint public blockNumber;
+    address compAddress;
 
     constructor() Comptroller() public {}
+
+    function setCompAddress(address compAddress_) public {
+        compAddress = compAddress_;
+    }
+
+    function getCompAddress() public view returns (address) {
+        return compAddress;
+    }
 
     function fastForward(uint blocks) public returns (uint) {
         blockNumber += blocks;
@@ -14,6 +23,10 @@ contract ComptrollerScenario is Comptroller {
 
     function setBlockNumber(uint number) public {
         blockNumber = number;
+    }
+
+    function getBlockNumber() public view returns (uint) {
+        return blockNumber;
     }
 
     function membershipLength(CToken cToken) public view returns (uint) {

--- a/tests/Flywheel/GasTest.js
+++ b/tests/Flywheel/GasTest.js
@@ -18,7 +18,6 @@ describe.skip('Flywheel trace ops', () => {
     [root, a1, a2, a3, ...accounts] = saddle.accounts;
     comptroller = await makeComptroller();
     market = await makeCToken({comptroller, supportMarket: true, underlyingPrice: 3, interestRateModelOpts});
-    await send(comptroller, '_addCompMarkets', [[market].map(c => c._address)]);
   });
 
   it('update supply index SSTOREs', async () => {


### PR DESCRIPTION
Before we go to v2, I want to remove some unused functions first. This slimming could be also applied to the current comptroller. After these changes, the comptroller could be reduced to 22.02 MB.

Followed by the previous PR.
Credits to [compound's PR by gauntlet](https://github.com/compound-finance/compound-protocol/pull/71), especially [Robert's comment](https://github.com/compound-finance/compound-protocol/pull/71#pullrequestreview-538885023). 