### PR TITLE
contracts/Unitroller.sol: add implementation

### DIFF
--- a/contracts/Unitroller.sol
+++ b/contracts/Unitroller.sol
@@ -128,6 +128,14 @@ contract Unitroller is UnitrollerAdminStorage, ComptrollerErrorReporter {
     }
 
     /**
+      * @notice This view function is for aligning with EIP-1967 interface
+      * @return The comptroller implementation
+      */
+    function implementation() public returns (address) {
+        return comptrollerImplementation;
+    }
+
+    /**
      * @dev Delegates execution to an implementation contract.
      * It returns to the external caller whatever the implementation returns
      * or forwards reverts.


### PR DESCRIPTION
We hoped to change Unitroller and cToken delegator to EIP-1967 proxy. However, it would break a lot of tests and OpenZeppelin is somehow incompatible with saddle. Therefore, we just added a view function called `implementation()` in Unitroller to make the interface aligning with EIP-1967.