### PR TITLE
tests/: add MockAggregator back

### DIFF
--- a/tests/Contracts/MockAggregator.sol
+++ b/tests/Contracts/MockAggregator.sol
@@ -2,7 +2,92 @@ pragma solidity ^0.5.16;
 
 import "../../contracts/PriceOracle/interfaces/FeedRegistryInterface.sol";
 
-contract MockAggregator is FeedRegistryInterface {
+interface AggregatorV3Interface {
+    function decimals() external view returns (uint8);
+
+    function description() external view returns (string memory);
+
+    function version() external view returns (uint256);
+
+    // getRoundData and latestRoundData should both raise "No data present"
+    // if they do not have data to report, instead of returning unset values
+    // which could be misinterpreted as actual reported values.
+    function getRoundData(uint80 _roundId)
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80 roundId,
+            int256 answer,
+            uint256 startedAt,
+            uint256 updatedAt,
+            uint80 answeredInRound
+        );
+}
+
+contract MockAggregator {
+    string public constant description = "mock aggregator";
+    uint256 public constant version = 1;
+    uint80 public constant roundId = 1;
+
+    uint8 public decimals = 18;
+    int256 public answer;
+
+    constructor(int256 _answer) public {
+        answer = _answer;
+    }
+
+    function getRoundData(uint80 _roundId)
+        external
+        view
+        returns (
+            uint80,
+            int256,
+            uint256,
+            uint256,
+            uint80
+        )
+    {
+        // Shh
+        _roundId;
+
+        return (roundId, answer, block.timestamp, block.timestamp, roundId);
+    }
+
+    function latestRoundData()
+        external
+        view
+        returns (
+            uint80,
+            int256,
+            uint256,
+            uint256,
+            uint80
+        )
+    {
+        return (roundId, answer, block.timestamp, block.timestamp, roundId);
+    }
+
+    function setAnswer(int256 _answer) external {
+        answer = _answer;
+    }
+
+    function setDecimals(uint8 _decimals) external {
+        decimals = _decimals;
+    }
+}
+
+contract MockRegistry is FeedRegistryInterface {
     uint80 public constant roundId = 1;
 
     int256 public answer;

--- a/tests/PriceOracleProxyTest.js
+++ b/tests/PriceOracleProxyTest.js
@@ -8,7 +8,7 @@ const {
   makeCToken,
   makeCurveSwap,
   makePriceOracle,
-  makeMockAggregator
+  makeMockRegistry
 } = require('./Utils/Compound');
 
 describe('PriceOracleProxy', () => {
@@ -27,7 +27,7 @@ describe('PriceOracleProxy', () => {
     cEth = await makeCToken({kind: "cether", comptrollerOpts: {kind: "v1-no-proxy"}, supportMarket: true});
     cDai = await makeCToken({comptroller: cEth.comptroller, supportMarket: true});
     cOther = await makeCToken({comptroller: cEth.comptroller, supportMarket: true});
-    mockAggregator = await makeMockAggregator({answer: price});
+    mockAggregator = await makeMockRegistry({answer: price});
 
     crvSwap = await makeCurveSwap({price: crvLPPrice});
     crvLP = await makeToken({kind: 'curveToken', symbol: 'ethCrv', name: 'Curve pool ethCrv', crvOpts: {minter: crvSwap._address}}); // ETH base

--- a/tests/Utils/Compound.js
+++ b/tests/Utils/Compound.js
@@ -398,6 +398,11 @@ async function makeMockAggregator(opts = {}) {
   return await deploy('MockAggregator', [answer]);
 }
 
+async function makeMockRegistry(opts = {}) {
+  const answer = dfn(opts.answer, etherMantissa(1));
+  return await deploy('MockRegistry', [answer]);
+}
+
 async function makeLiquidityMining(opts = {}) {
   const comptroller = opts.comptroller || await makeComptroller(opts.comptrollerOpts);
   return await deploy('MockLiquidityMining', [comptroller._address]);
@@ -613,9 +618,10 @@ module.exports = {
   makeCToken,
   makeInterestRateModel,
   makePriceOracle,
-  makeToken,
-  makeFlashloanReceiver,
   makeMockAggregator,
+  makeMockRegistry,
+  makeFlashloanReceiver,
+  makeToken,
   makeCurveSwap,
   makeLiquidityMining,
   makeCTokenAdmin,


### PR DESCRIPTION
The old MockAggregator is needed for tests because other networks might not have a registry.